### PR TITLE
Hi Michael,

### DIFF
--- a/src/main/grammars/siunit/monticoresiunit/SI.mc4
+++ b/src/main/grammars/siunit/monticoresiunit/SI.mc4
@@ -145,7 +145,7 @@ grammar SI {
      "cwt" | // hundredweight
      // "t" | // imperial ton // conflict with metric tonne
      "slug" | // slug
-     "°F"  // degree Fahrenheit
+     "\u00B0F"  // degree Fahrenheit
 
   ;
 
@@ -183,7 +183,7 @@ grammar SI {
     "min" | // minute
     "h" | // hour
     "d" | // day
-    "°" | // degree
+    "\u00B0" | // degree
 	// ToDo: fix escapeing
     /*
     "\\'" | // minute
@@ -229,7 +229,7 @@ grammar SI {
     "Wb" | // weber
     "T" | // tesla
     "H" | // henry
-    "°C" | // degree Celsius
+    "\u00B0C" | // degree Celsius
     "lm" | // lumen
     "lx" | // lux
     "Bq" | // becquerel

--- a/src/test/java/siunit/monticoresiunit/SIParserTest.java
+++ b/src/test/java/siunit/monticoresiunit/SIParserTest.java
@@ -61,6 +61,10 @@ public class SIParserTest {
         SIParser parser = new SIParser();
         ASTNumber ast = parser.parse_String("7°").orElse(null);
         assertNotNull(ast);
+        ast = parser.parse_String("-9°C").orElse(null);
+        assertNotNull(ast);
+        assertEquals(Rational.valueOf(-9,1), ast.getUnitNumber().get().getNumber().get());
+        assertEquals(Unit.valueOf("°C"), ast.getUnitNumber().get().getUnit().get());
 	}
 
     @Test


### PR DESCRIPTION
nach langem Suchen habe ich eine Lösung gefunden. Problem ist wohl Antlr, der je nach Umgebung (Diese bestimmt, welches Encoding gesetzt ist.) unterschiedliche Lexer generiert. Man kann Antlr zwar auch explizit ein Encoding angeben, aber da ist er bei mir immer abgestürzt.
Folgendes hat allerdings bei mir funktioniert: Ändere die Beschreibung von ‚°‘ in ‚\u00B0‘.

Viele Grüße
  Marita